### PR TITLE
Update EZTools.cs - Changed RecordNumber and EventRecordID from `string` to `int`

### DIFF
--- a/TLEFileEZTools/EZTools.cs
+++ b/TLEFileEZTools/EZTools.cs
@@ -1063,8 +1063,8 @@ namespace TLEFileEZTools
 
     public class EvtxECmdData : IFileSpecData
     {
-        public string RecordNumber { get; set; }
-        public string EventRecordId { get; set; }
+        public int RecordNumber { get; set; }
+        public int EventRecordId { get; set; }
         public DateTime TimeCreated { get; set; }
         public int EventId { get; set; }
         public string Level { get; set; }


### PR DESCRIPTION
RecordNumber and EventRecordID were sorting as `string` before Now they are `int`. Will help with sorting on those values!