### PR TITLE
Updated GenericCsv to detect delimiter used

### DIFF
--- a/TLEFileGenericCsv/GenericCsv.cs
+++ b/TLEFileGenericCsv/GenericCsv.cs
@@ -4,6 +4,7 @@ using System.ComponentModel;
 using System.Dynamic;
 using System.Globalization;
 using System.IO;
+using System.Linq;
 using CsvHelper;
 using CsvHelper.Configuration;
 using ITLEFileSpec;
@@ -30,32 +31,31 @@ namespace TLEFileGenericCsv
         public List<int> TaggedLines { get; set; }
         public string InternalGuid => "40dd7405-16cf-4612-a480-9a050d0a9952";
 
-      
+
 
         private ExpandoObject ConvertToDynamic(IDictionary<string, object> fastDynamicObject) {
             if (fastDynamicObject == null) return null;  
             IDictionary<string,object> result = new ExpandoObject();
-            foreach (var item in fastDynamicObject) 
+            foreach (var item in fastDynamicObject) {
+                if (string.IsNullOrWhiteSpace(item.Key))
+                    continue; // skip invalid keys
                 result.Add(item.Key, item.Value);
+            }
             return (ExpandoObject)result;
         }
         
         
         public void ProcessFile(string filename)
         {
-            
-
             var tempList = new List<dynamic>();
 
             using var fileReader = File.Open(filename, FileMode.Open, FileAccess.Read);
             using var ff = new StreamReader(fileReader);
             var config = new CsvConfiguration(CultureInfo.InvariantCulture)
             {
-                //  BadDataFound = null,
-                    
                 BadDataFound = context =>
                 {
-                    Log.Warning("Bad data found in {Field}! Skipping. Raw data: {RawRecord}",context.Field, context.RawRecord);
+                    Log.Warning("Bad data found in {Field}! Skipping. Raw data: {RawRecord}", context.Field, context.RawRecord);
                 },
             };
 
@@ -67,10 +67,30 @@ namespace TLEFileGenericCsv
                     Delimiter = "\t"
                 };
             }
+            else {
+                // Possible delimiters
+                var delimiters = new Dictionary<char, int> { { ',', 0 }, { '\t', 0 }, { '|', 0 }, { ';', 0 } };
 
+                var firstLine = ff.ReadLine();
+                foreach (var delimiter in delimiters)
+                {
+                    // Find the delimiter that has the most occurrences
+                    var count = firstLine.Count(c => c == delimiter.Key);
+                    delimiters[delimiter.Key] = count;
+                }
+
+                Log.Debug("Delimiters: {Delimiters}", delimiters);
+
+                // Find the delimiter with the most occurrences
+                var maxDelimiter = delimiters.OrderByDescending(d => d.Value).First().Key;
+                Log.Debug("Max delimiter: {MaxDelimiter}", maxDelimiter);
+
+                config.Delimiter = maxDelimiter.ToString();
+            }
+
+            ff.BaseStream.Seek(0, SeekOrigin.Begin);
+            ff.DiscardBufferedData();
             var csv = new CsvReader(ff, config);
-            
-            
 
             var ln = 1;
             while (csv.Read())
@@ -79,27 +99,19 @@ namespace TLEFileGenericCsv
                 {
                     csv.Read();
                 }
-                
-                
-                Log.Debug("Line # {Line}, Record: {RawRecord}",ln,csv.Context.Parser.RawRecord);
 
-               var f = csv.GetRecord<dynamic>();
-               f.Line = ln;
-               f.Tag = TaggedLines.Contains(ln);
-               
-                ExpandoObject f1= ConvertToDynamic(f);
-                
-                
-                
+                Log.Debug("Line # {Line}, Record: {RawRecord}", ln, csv.Context.Parser.RawRecord);
+
+                var f = csv.GetRecord<dynamic>();
+                f.Line = ln;
+                f.Tag = TaggedLines.Contains(ln);
+
+                ExpandoObject f1 = ConvertToDynamic(f);
 
                 tempList.Add(f1);
 
                 ln += 1;
             }
-
-            // var records = csv.GetRecords<dynamic>().ToList();
-            
-            
 
             DataList = new BindingList<dynamic>(tempList);
         }

--- a/TLEFilePlugins.sln
+++ b/TLEFilePlugins.sln
@@ -19,6 +19,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TLEFileTzWorks", "TLEFileTz
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TLEFileMisc", "TLEFileMisc\TLEFileMisc.csproj", "{EFBB6815-A8EC-40D5-83FF-5D73DB540116}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TLEFileIrregularCsv", "TLEFileIrregularCsv\TLEFileIrregularCsv.csproj", "{6ae4179a-63f7-4a6a-a2ab-077c8882a056}"
+EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TLEFile.Test", "TLEFile.Test\TLEFile.Test.csproj", "{6A9F9E57-170A-4959-8768-0C0EBBDDCBE8}"
 EndProject
 Global
@@ -59,6 +61,10 @@ Global
 		{EFBB6815-A8EC-40D5-83FF-5D73DB540116}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{EFBB6815-A8EC-40D5-83FF-5D73DB540116}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{EFBB6815-A8EC-40D5-83FF-5D73DB540116}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6ae4179a-63f7-4a6a-a2ab-077c8882a056}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6ae4179a-63f7-4a6a-a2ab-077c8882a056}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6ae4179a-63f7-4a6a-a2ab-077c8882a056}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6ae4179a-63f7-4a6a-a2ab-077c8882a056}.Release|Any CPU.Build.0 = Release|Any CPU
 		{6A9F9E57-170A-4959-8768-0C0EBBDDCBE8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{6A9F9E57-170A-4959-8768-0C0EBBDDCBE8}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{6A9F9E57-170A-4959-8768-0C0EBBDDCBE8}.Release|Any CPU.ActiveCfg = Release|Any CPU

--- a/TLEFilePlugins.sln
+++ b/TLEFilePlugins.sln
@@ -19,8 +19,6 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TLEFileTzWorks", "TLEFileTz
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TLEFileMisc", "TLEFileMisc\TLEFileMisc.csproj", "{EFBB6815-A8EC-40D5-83FF-5D73DB540116}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TLEFileIrregularCsv", "TLEFileIrregularCsv\TLEFileIrregularCsv.csproj", "{6ae4179a-63f7-4a6a-a2ab-077c8882a056}"
-EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TLEFile.Test", "TLEFile.Test\TLEFile.Test.csproj", "{6A9F9E57-170A-4959-8768-0C0EBBDDCBE8}"
 EndProject
 Global
@@ -61,10 +59,6 @@ Global
 		{EFBB6815-A8EC-40D5-83FF-5D73DB540116}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{EFBB6815-A8EC-40D5-83FF-5D73DB540116}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{EFBB6815-A8EC-40D5-83FF-5D73DB540116}.Release|Any CPU.Build.0 = Release|Any CPU
-		{6ae4179a-63f7-4a6a-a2ab-077c8882a056}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{6ae4179a-63f7-4a6a-a2ab-077c8882a056}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{6ae4179a-63f7-4a6a-a2ab-077c8882a056}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{6ae4179a-63f7-4a6a-a2ab-077c8882a056}.Release|Any CPU.Build.0 = Release|Any CPU
 		{6A9F9E57-170A-4959-8768-0C0EBBDDCBE8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{6A9F9E57-170A-4959-8768-0C0EBBDDCBE8}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{6A9F9E57-170A-4959-8768-0C0EBBDDCBE8}.Release|Any CPU.ActiveCfg = Release|Any CPU


### PR DESCRIPTION
Updated `GenericCsv` Plugin to identify delimiter used in the CSV file. 

1. It iterates through the list of possible characters (`,`, `\t`, `|`, `;`) in the first line.
2. Then uses the character with the most occurrences as the delimiter.